### PR TITLE
None extract_resources_request returns 400

### DIFF
--- a/src/apis/fleet_api.rs
+++ b/src/apis/fleet_api.rs
@@ -399,7 +399,11 @@ pub async fn extract_resources(configuration: &configuration::Configuration, shi
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
     if let Some(ref local_var_extract_resources) = extract_resources_request {
-        local_var_req_builder = local_var_req_builder.json(&local_var_extract_resources);
+        if let Some(_) = &local_var_extract_resources.survey {
+            local_var_req_builder = local_var_req_builder.json(&extract_resources_request);
+        } else {
+            local_var_req_builder = local_var_req_builder.header("Content-Length", "0")
+        }
     } else {
         local_var_req_builder = local_var_req_builder.header("Content-Length", "0")
     }

--- a/src/apis/fleet_api.rs
+++ b/src/apis/fleet_api.rs
@@ -398,7 +398,11 @@ pub async fn extract_resources(configuration: &configuration::Configuration, shi
     if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
-    local_var_req_builder = local_var_req_builder.json(&extract_resources_request);
+    if let Some(ref local_var_extract_resources) = extract_resources_request {
+        local_var_req_builder = local_var_req_builder.json(&local_var_extract_resources);
+    } else {
+        local_var_req_builder = local_var_req_builder.header("Content-Length", "0")
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;
@@ -991,4 +995,3 @@ pub async fn warp_ship(configuration: &configuration::Configuration, ship_symbol
         Err(Error::ResponseError(local_var_error))
     }
 }
-


### PR DESCRIPTION
When calling:
`extract_resources(&config, &symbol, None)`

You get a 400 error, due to a json body being added without size.

Seems like Content-Length also needs to be set for requests which can have a json attached else you get 411.